### PR TITLE
relp: Wasn't setting servers correctly

### DIFF
--- a/templates/default/49-relp.conf.erb
+++ b/templates/default/49-relp.conf.erb
@@ -4,7 +4,7 @@ $ActionQueueType LinkedList # use asynchronous processing
 $ActionQueueFileName srvrfwd # set file name, also enables disk mode
 $ActionResumeRetryCount -1 # infinite retries on insert failure
 $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
-<% @servers.each do |server| -%> 
-*.* :omrelp:<%= "#{server}:#{node['rsyslog']['relp_port']}" %>
-<% end -%> 
 
+<% @servers.each do |server| -%>
+*.* :omrelp:<%= "#{server}:#{node['rsyslog']['relp_port']}" %><%= node['rsyslog']['default_remote_template'] ? ';' + node['rsyslog']['default_remote_template'] : nil %>
+<% end -%>


### PR DESCRIPTION
The `49-relp.conf` wasn't using the `@servers` variable (was using
`@server` instead).  This fix lets it use the list of servers
automatically discovered in the `client` recipe.