### PR TITLE
Lwrp only notifies when changed

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,3 +39,6 @@ suites:
   - name: server
     run_list:
       - recipe[rsyslog_test::server]
+  - name: input_file_provider
+    run_list:
+      - recipe[rsyslog_test::input_file_provider]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
-    - vendor/**
+    - vendor/**/*
+    - Guardfile
 
 AlignParameters:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :unit do
   gem 'berkshelf',  '~> 3.2.0'
-  gem 'chefspec',   '~> 3.1'
+  gem 'chefspec',   '~> 4.0'
 end
 
 group :kitchen_common do

--- a/Rakefile
+++ b/Rakefile
@@ -20,9 +20,9 @@ end
 desc 'Run all style checks'
 task style: ['style:chef', 'style:ruby']
 
-# # Rspec and ChefSpec
-# desc "Run ChefSpec examples"
-# RSpec::Core::RakeTask.new(:spec)
+# Rspec and ChefSpec
+desc 'Run ChefSpec examples'
+RSpec::Core::RakeTask.new(:spec)
 
 # Integration tests. Kitchen.ci
 namespace :integration do
@@ -53,9 +53,7 @@ namespace :integration do
 end
 
 desc 'Run all tests on Travis'
-# task travis: ['style', 'spec', 'integration:cloud']
-task travis: ['style', 'integration:cloud']
+task travis: ['style', 'spec', 'integration:cloud']
 
 # Default
-# task default: ['style', 'spec', 'integration:vagrant']
-task default: ['style', 'integration:vagrant']
+task default: ['style', 'spec', 'integration:vagrant']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,17 @@
+module RsyslogCookbook
+  module Helpers
+    def declare_rsyslog_service
+      if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
+        service_provider = Chef::Provider::Service::Upstart
+      else
+        service_provider = nil
+      end
+
+      service node['rsyslog']['service_name'] do
+        supports :restart => true, :status => true
+        action   [:enable, :start]
+        provider service_provider
+      end
+    end
+  end
+end

--- a/providers/file_input.rb
+++ b/providers/file_input.rb
@@ -16,8 +16,10 @@
 # limitations under the License.
 #
 
+use_inline_resources
+
 action :create do
-  template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
+  t = template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
     mode '0664'
     owner node['rsyslog']['user']
     group node['rsyslog']['group']
@@ -28,6 +30,8 @@ action :create do
               'state_file' => new_resource.name,
               'severity' => new_resource.severity,
               'facility' => new_resource.facility
-    notifies :restart, resources(:service => 'rsyslog')
+    notifies :restart, resources('service[rsyslog]')
   end
+
+  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end

--- a/providers/file_input.rb
+++ b/providers/file_input.rb
@@ -19,7 +19,7 @@
 use_inline_resources
 
 action :create do
-  t = template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
+  template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
     mode '0664'
     owner node['rsyslog']['user']
     group node['rsyslog']['group']
@@ -30,8 +30,7 @@ action :create do
               'state_file' => new_resource.name,
               'severity' => new_resource.severity,
               'facility' => new_resource.facility
+    notifies :nothing, resources('service[rsyslog]')
     notifies :restart, resources('service[rsyslog]')
   end
-
-  new_resource.updated_by_last_action(t.updated_by_last_action?)
 end

--- a/providers/file_input.rb
+++ b/providers/file_input.rb
@@ -18,7 +18,11 @@
 
 use_inline_resources
 
+include RsyslogCookbook::Helpers
+
 action :create do
+  declare_rsyslog_service
+
   template "/etc/rsyslog.d/#{new_resource.priority}-#{new_resource.name}.conf" do
     mode '0664'
     owner node['rsyslog']['user']
@@ -30,7 +34,6 @@ action :create do
               'state_file' => new_resource.name,
               'severity' => new_resource.severity,
               'facility' => new_resource.facility
-    notifies :nothing, resources('service[rsyslog]')
     notifies :restart, resources('service[rsyslog]')
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+::Chef::Recipe.send(:include, RsyslogCookbook::Helpers)
+
 package 'rsyslog'
 package 'rsyslog-relp' if node['rsyslog']['use_relp']
 
@@ -84,14 +86,4 @@ if platform_family?('omnios')
   end
 end
 
-if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 12.04
-  service_provider = Chef::Provider::Service::Upstart
-else
-  service_provider = nil
-end
-
-service node['rsyslog']['service_name'] do
-  supports :restart => true, :status => true
-  action   [:enable, :start]
-  provider service_provider
-end
+declare_rsyslog_service

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-::Chef::Recipe.send(:include, RsyslogCookbook::Helpers)
+extend RsyslogCookbook::Helpers
 
 package 'rsyslog'
 package 'rsyslog-relp' if node['rsyslog']['use_relp']

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -116,8 +116,8 @@ describe 'rsyslog::default' do
     end
 
     it 'is owned by root:root' do
-      expect(directory.owner).to eq('root')
-      expect(directory.group).to eq('root')
+      expect(directory.owner).to eq('syslog')
+      expect(directory.group).to eq('adm')
     end
 
     it 'has 0700 permissions' do

--- a/test/fixtures/rsyslog_test/recipes/input_file_provider.rb
+++ b/test/fixtures/rsyslog_test/recipes/input_file_provider.rb
@@ -1,0 +1,3 @@
+rsyslog_file_input 'test-file' do
+  file '/var/log/boot'
+end

--- a/test/integration/input_file_provider/bats/verify_input_file_provider.bats
+++ b/test/integration/input_file_provider/bats/verify_input_file_provider.bats
@@ -1,0 +1,7 @@
+@test "the input_file is created" {
+  test /etc/rsyslog.d/99-test-file.conf
+}
+
+@test "the input_file contains given file" {
+  grep "InputFileName /var/log/boot" /etc/rsyslog.d/99-test-file.conf
+}


### PR DESCRIPTION
Make `file_input` LWRP only notify when underlying `template` resource changes, use `use_inline_resources`.

This also includes:

- Do not check `Guardfile` in rubocop
- Fix `FC017` error in notifying syntax
- Change `vendor/**` to `vendor/**/*` to remove a deprecation
- Fix ChefSpec tests and include it in `travis` and `default` tasks