### PR TITLE
Treat Amazon Linux like RH6, not RH7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,8 +70,8 @@ when 'rhel', 'fedora'
     'uucp,news.crit' => "#{node['rsyslog']['default_log_dir']}/spooler",
     'local7.*' => "#{node['rsyslog']['default_log_dir']}/boot.log"
   }
-  # RHEL >= 7 and Fedora >= 19 use journald in systemd
-  if node['platform_version'].to_i == 7 || node['platform_version'].to_i >= 19
+  # RHEL >= 7 and Fedora >= 19 use journald in systemd. Amazon Linux doesn't.
+  if node['platform'] != "amazon" && (node['platform_version'].to_i == 7 || node['platform_version'].to_i >= 19)
     default['rsyslog']['modules'] = %w(imuxsock imjournal)
     default['rsyslog']['additional_directives'] = { 'OmitLocalLogging' => 'on', 'IMJournalStateFile' => 'imjournal.state' }
   end


### PR DESCRIPTION
When I build an rsyslog client on Amazon Linux 2014.09.1, the rsyslog cookbook treats that OS as if it is RHEL 7 and configures rsyslog to use journald.  Amazon LInux does not run journald so that breaks some things.  For instance, the `/dev/log` socket doesn't get created.