### PR TITLE
[#74] Add configurable permission drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['remote_logs']` - Specify wether to send all logs to a remote server (client option). Default is `true`.
 * `node['rsyslog']['per_host_dir']` - "PerHost" directories for template statements in `35-server-per-host.conf`. Default value is the previous cookbook version's value, to preserve compatibility. See __server__ recipe below.
 * `node['rsyslog']['priv_seperation']` - Whether to use privilege separation or not.
+* `node['rsyslog']['priv_user']` - User to run as when using privilege separation. Defult is  `node['rsyslog']['user']`
+* `node['rsyslog']['priv_group']` - Group to run as when using privilege separation. Defult is  `node['rsyslog']['group']`
 * `node['rsyslog']['max_message_size']` - Specify the maximum allowed message size. Default is 2k.
 * `node['rsyslog']['user']` - Who should own the configuration files and directories
 * `node['rsyslog']['group']` - Who should group-own the configuration files and directories

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,8 @@ default['rsyslog']['service_name']              = 'rsyslog'
 default['rsyslog']['user']                      = 'root'
 default['rsyslog']['group']                     = 'adm'
 default['rsyslog']['priv_seperation']           = false
+default['rsyslog']['priv_user']                 = nil
+default['rsyslog']['priv_group']                = nil
 default['rsyslog']['modules']                   = %w(imuxsock imklog)
 
 # platform family specific attributes
@@ -105,6 +107,7 @@ when 'ubuntu'
     default['rsyslog']['user'] = 'syslog'
     default['rsyslog']['group'] = 'adm'
     default['rsyslog']['priv_seperation'] = true
+    default['rsyslog']['priv_group'] = 'syslog'
   end
 when 'arch'
   default['rsyslog']['service_name'] = 'rsyslogd'

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -81,8 +81,8 @@ $FileCreateMode 0640
 $DirCreateMode 0755
 $Umask 0022
 <% if node['rsyslog']['priv_seperation'] %>
-$PrivDropToUser <%= node['rsyslog']['user'] %>
-$PrivDropToGroup <%= node['rsyslog']['group'] %>
+$PrivDropToUser <%= node['rsyslog']['priv_user'] || node['rsyslog']['user'] %>
+$PrivDropToGroup <%= node['rsyslog']['priv_group'] || node['rsyslog']['group'] %>
 <% end %>
 <% unless node['rsyslog']['rate_limit_interval'].nil? %>
 #


### PR DESCRIPTION
Ubuntu expects rsyslog to drop permissions to syslog:syslog

Fixes #74 