### PR TITLE
add allow_non_local option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['tls_key_file']` - Path to TLS key file. Required for server, optional for clients.
 * `node['rsyslog']['tls_auth_mode']` - Value for `$InputTCPServerStreamDriverAuthMode`/`$ActionSendStreamDriverAuthMode`, determines whether client certs are validated. Defaults to `anon` (no validation).
 * `node['rsyslog']['use_local_ipv4']` - Whether or not to make use the remote local IPv4 address on cloud systems when searching for servers (where available).  Default is 'false'.
+* `node['rsyslog']['allow_non_local']` - Whether or not to allow non-local messages. If 'false', incoming messages are only allowed from 127.0.0.1. Default is 'false'.
 * `node['rsyslog']['additional_directives']` - Hash of additional directives and their values to place in the main rsyslog config file
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ default['rsyslog']['tls_certificate_file']      = nil
 default['rsyslog']['tls_key_file']              = nil
 default['rsyslog']['tls_auth_mode']             = 'anon'
 default['rsyslog']['use_local_ipv4']            = false
+default['rsyslog']['allow_non_local']           = false
 default['rsyslog']['additional_directives'] = {}
 
 # The most likely platform-specific attributes

--- a/metadata.rb
+++ b/metadata.rb
@@ -124,3 +124,8 @@ attribute 'rsyslog/use_local_ipv4',
   :display_name => 'Try to use local IPv4 address',
   :description => 'Whether or not to make use the remote local IPv4 address on cloud systems when searching for servers (where available).',
   :default => 'false'
+
+attribute 'rsyslog/allow_non_local',
+  :display_name => 'Allow non-local messages',
+  :description => 'Allow processing of messages coming any IP, not just 127.0.0.1',
+  :default => 'false'

--- a/templates/default/35-server-per-host.conf.erb
+++ b/templates/default/35-server-per-host.conf.erb
@@ -52,8 +52,11 @@ news.notice             -?PerHostNewsNotice
   cron,daemon.none;\
   mail,news.none        -?PerHostMessages
 
+
+<% unless node['rsyslog']['allow_non_local'] -%>
 #
 # Stop processing of all non-local messages. You can process remote messages
 # on levels less than 35.
 #
 :fromhost-ip,!isequal,"127.0.0.1" ~
+<% end -%>


### PR DESCRIPTION
This piece in *templates/default/35-server-per-host.conf.erb* was causing issues for my setup:
```
:fromhost-ip,!isequal,"127.0.0.1" ~
```

Specifically, I was trying to access the rsyslog server from within a [logspout](https://github.com/gliderlabs/logspout) Docker container on the same host (different IPs).

Added the 'allow_non_local' option to make that line optional. Merge if you wish!