### PR TITLE
Fix Log folder permission.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,8 +23,8 @@ node.set['rsyslog']['server'] = true
 include_recipe 'rsyslog::default'
 
 directory node['rsyslog']['log_dir'] do
-  owner    'root'
-  group    'root'
+  owner    node['rsyslog']['user'] ? node['rsyslog']['user']  : 'root'
+  group    node['rsyslog']['group'] ? node['rsyslog']['group']  : 'root'
   mode     '0755'
   recursive true
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,8 +23,8 @@ node.set['rsyslog']['server'] = true
 include_recipe 'rsyslog::default'
 
 directory node['rsyslog']['log_dir'] do
-  owner    node['rsyslog']['user'] ? node['rsyslog']['user']  : 'root'
-  group    node['rsyslog']['group'] ? node['rsyslog']['group']  : 'root'
+  owner    node['rsyslog']['user']
+  group    node['rsyslog']['group']
   mode     '0755'
   recursive true
 end


### PR DESCRIPTION
If folder owner set to root but rsyslog is running as 'syslog' user then it can not write these files and silently fails.