### PR TITLE
Allow server to bind on specific UDP address (default: '*').

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['server_ip']` - If not defined then search will be used to determine rsyslog server. Default is `nil`.  This can be a string or an array.
 * `node['rsyslog']['server_search']` - Specify the criteria for the server search operation. Default is `role:loghost`.
 * `node['rsyslog']['protocol']` - Specify whether to use `udp` or `tcp` for remote loghost. Default is `tcp`.
+* `node['rsyslog']['bind']` - Specify the address to which the server should be listening; only use with `node['rsyslog']['protocol'] = 'udp'` because the feature does not work with the `tcp` protocol ([more info](http://www.rsyslog.com/doc/master/configuration/modules/imtcp.html#caveats-known-bugs)).
 * `node['rsyslog']['port']` - Specify the port which rsyslog should connect to a remote loghost.
 * `node['rsyslog']['remote_logs']` - Specify wether to send all logs to a remote server (client option). Default is `true`.
 * `node['rsyslog']['per_host_dir']` - "PerHost" directories for template statements in `35-server-per-host.conf`. Default value is the previous cookbook version's value, to preserve compatibility. See __server__ recipe below.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['rsyslog']['server']                    = false
 default['rsyslog']['use_relp']                  = false
 default['rsyslog']['relp_port']                 = 20_514
 default['rsyslog']['protocol']                  = 'tcp'
+default['rsyslog']['bind']                      = '*'
 default['rsyslog']['port']                      = 514
 default['rsyslog']['server_ip']                 = nil
 default['rsyslog']['server_search']             = 'role:loghost'

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -42,6 +42,7 @@ $ModLoad imtcp
 $InputTCPServerRun <%= node['rsyslog']['port'] %>
 <% when "udp" -%>
 $ModLoad imudp
+$UDPServerAddress <%= node['rsyslog']['bind'] %>
 $UDPServerRun <%= node['rsyslog']['port'] %>
 <% end -%>
   <% end -%>


### PR DESCRIPTION
This PR allows the rsyslogd server to bind to a specific UDP address (default is to bind to all addresses). It fixes #55.

Notes:
 - I have not tested how binding to a single interface works without `rsyslog.server_ip`.
 - I use the [legacy](http://www.rsyslog.com/doc/master/configuration/modules/imudp.html#legacy-configuration-directives) `$UDPServerAddress` directive by consistency with the use of `$UDPServerRun` in the existing configuration file.
 - the `tcp` protocol is [not supported](http://www.rsyslog.com/doc/master/configuration/modules/imtcp.html#caveats-known-bugs).