### PR TITLE
allow the use of both tcp and udp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['server']` - Determined automatically and set to true on the server.
 * `node['rsyslog']['server_ip']` - If not defined then search will be used to determine rsyslog server. Default is `nil`.  This can be a string or an array.
 * `node['rsyslog']['server_search']` - Specify the criteria for the server search operation. Default is `role:loghost`.
-* `node['rsyslog']['protocol']` - Specify whether to use `udp` or `tcp` for remote loghost. Default is `tcp`.
+* `node['rsyslog']['protocol']` - Specify whether to use `udp` or `tcp` for remote loghost. Default is `tcp`. To use both specify both in a string e.g. 'udptcp'.
 * `node['rsyslog']['port']` - Specify the port which rsyslog should connect to a remote loghost.
 * `node['rsyslog']['remote_logs']` - Specify wether to send all logs to a remote server (client option). Default is `true`.
 * `node['rsyslog']['per_host_dir']` - "PerHost" directories for template statements in `35-server-per-host.conf`. Default value is the previous cookbook version's value, to preserve compatibility. See __server__ recipe below.

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -36,13 +36,13 @@ $InputTCPServerStreamDriverAuthMode <%= node['rsyslog']['tls_auth_mode'] || 'ano
 $InputTCPServerRun <%= node['rsyslog']['port'] %>
 # Provide <%= node['rsyslog']['protocol'].upcase %> log reception
   <% else -%>
-<% case node['rsyslog']['protocol'] -%>
-<% when "tcp" -%>
-$ModLoad imtcp
-$InputTCPServerRun <%= node['rsyslog']['port'] %>
-<% when "udp" -%>
-$ModLoad imudp
-$UDPServerRun <%= node['rsyslog']['port'] %>
+<% if node['rsyslog']['protocol'] =~ /tcp/ %>
+  $ModLoad imtcp
+  $InputTCPServerRun <%= node['rsyslog']['port'] %>
+<% end -%>
+<% if node['rsyslog']['protocol'] =~ /udp/ %>
+  $ModLoad imudp
+  $UDPServerRun <%= node['rsyslog']['port'] %>
 <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
allow the use of both tcp and udp, by defining udp + tcp in the protocol string (e.g. "udp,tcp" or any format that will match the if statement)