### PR TITLE
Move additional directives before includes

### DIFF
--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -97,10 +97,15 @@ $SystemLogRateLimitInterval <%= node['rsyslog']['rate_limit_interval'] %>
 #
 $SystemLogRateLimitBurst <%= node['rsyslog']['rate_limit_burst'] %>
 <% end %>
+
+#
+# Set other directives
+#
+<% node['rsyslog']['additional_directives'].each_pair do |k,v| %>
+$<%= k %> <%= v %>
+<% end %>
+
 #
 # Include all config files in <%= node['rsyslog']['config_prefix'] %>/rsyslog.d/
 #
 $IncludeConfig <%= node['rsyslog']['config_prefix'] %>/rsyslog.d/*.conf
-<% node['rsyslog']['additional_directives'].each_pair do |k,v| %>
-$<%= k %> <%= v %>
-<% end %>


### PR DESCRIPTION
This allows for settings to cascade down into included configs and also allows settings to be overwritten in included configs.
